### PR TITLE
Switch to GPT-Image-1 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Right Click to Image
 
-This Chrome extension sends highlighted text to OpenAI's latest DALL-E 3 image
+This Chrome extension sends highlighted text to OpenAI's GPT-Image-1 image
 generation API and displays the resulting image in a new window. The image is
 saved automatically to your Downloads folder.
 
@@ -8,7 +8,8 @@ saved automatically to your Downloads folder.
 
 - Highlight text and use the context menu or the extension button to generate an image.
 - OpenAI API key stored via the options page.
-- Choose image size and style in settings.
+- Choose image size, quality and OpenAI style in settings.
+- Append custom style text to the prompt.
 - Shows a progress window while the image is being generated.
 - Errors are shown as popup alerts when generation fails.
 

--- a/background.js
+++ b/background.js
@@ -17,13 +17,15 @@ async function getSelectedText(tabId) {
 async function generateImageFromSelection(tab) {
   const text = await getSelectedText(tab.id);
   if (!text) return;
-  const opts = await chrome.storage.local.get(['apiKey', 'size', 'style']);
+  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'openaiStyle', 'stylePrompt']);
   if (!opts.apiKey) {
     chrome.runtime.openOptionsPage();
     return;
   }
-  const prompt = opts.style ? `${text}, ${opts.style}` : text;
-  let size = opts.size || '1024x1024';
+  const prompt = opts.stylePrompt ? `${text}, ${opts.stylePrompt}` : text;
+  const size = opts.size || '1024x1024';
+  const quality = opts.quality || 'standard';
+  const style = opts.openaiStyle || 'vivid';
   let progressWin;
   try {
     progressWin = await chrome.windows.create({
@@ -39,7 +41,14 @@ async function generateImageFromSelection(tab) {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${opts.apiKey}`
       },
-      body: JSON.stringify({prompt, n: 1, size, model: 'dall-e-3'})
+      body: JSON.stringify({
+        prompt,
+        n: 1,
+        size,
+        model: 'gpt-image-1',
+        quality,
+        style
+      })
     });
     const data = await resp.json();
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Right Click to Image",
-  "description": "Generate images from selected text via OpenAI DALL-E 3",
-  "version": "1.1",
+  "description": "Generate images from selected text via OpenAI GPT-Image-1",
+  "version": "1.2",
   "permissions": [
     "contextMenus",
     "activeTab",

--- a/options.html
+++ b/options.html
@@ -14,13 +14,20 @@
       <option value="1792x1024">1792x1024</option>
     </select>
   </label><br>
-  <label>Style:
-    <select id="style">
-      <option value="">None</option>
-      <option value="cartoon">Cartoon</option>
-      <option value="photorealistic">Photorealistic</option>
-      <option value="oil painting">Oil Painting</option>
+  <label>Quality:
+    <select id="quality">
+      <option value="standard">Standard</option>
+      <option value="hd">HD</option>
     </select>
+  </label><br>
+  <label>OpenAI Style:
+    <select id="openaiStyle">
+      <option value="vivid">Vivid</option>
+      <option value="natural">Natural</option>
+    </select>
+  </label><br>
+  <label>Additional Style Text:
+    <input id="stylePrompt" type="text" placeholder="e.g. cartoon, photorealistic">
   </label><br>
   <button id="save">Save</button>
   <div id="status"></div>

--- a/options.js
+++ b/options.js
@@ -1,15 +1,19 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  const opts = await chrome.storage.local.get(['apiKey', 'size', 'style']);
+  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'openaiStyle', 'stylePrompt']);
   if (opts.apiKey) document.getElementById('apiKey').value = opts.apiKey;
   if (opts.size) document.getElementById('size').value = opts.size;
-  if (opts.style) document.getElementById('style').value = opts.style;
+  if (opts.quality) document.getElementById('quality').value = opts.quality;
+  if (opts.openaiStyle) document.getElementById('openaiStyle').value = opts.openaiStyle;
+  if (opts.stylePrompt) document.getElementById('stylePrompt').value = opts.stylePrompt;
 });
 
 document.getElementById('save').addEventListener('click', async () => {
   const apiKey = document.getElementById('apiKey').value;
   const size = document.getElementById('size').value;
-  const style = document.getElementById('style').value;
-  await chrome.storage.local.set({apiKey, size, style});
+  const quality = document.getElementById('quality').value;
+  const openaiStyle = document.getElementById('openaiStyle').value;
+  const stylePrompt = document.getElementById('stylePrompt').value;
+  await chrome.storage.local.set({apiKey, size, quality, openaiStyle, stylePrompt});
   const status = document.getElementById('status');
   status.textContent = 'Saved!';
   setTimeout(() => status.textContent = '', 1000);


### PR DESCRIPTION
## Summary
- migrate to GPT-Image-1 for image generation
- add UI options for OpenAI style, quality, and custom style text
- support new parameters in background script
- document GPT-Image-1 usage and new options

## Testing
- `node -v`
- `node -c background.js`
- `node -c options.js`


------
https://chatgpt.com/codex/tasks/task_e_688684cec7d08323a24e36be3487eb40