### PR TITLE
Fix style parameter with gpt-image-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ saved automatically to your Downloads folder.
 
 - Highlight text and use the context menu or the extension button to generate an image.
 - OpenAI API key stored via the options page.
-- Choose image size, quality and OpenAI style in settings.
+- Choose image size and quality in settings.
 - Append custom style text to the prompt.
 - Shows a progress window while the image is being generated.
 - Errors are shown as popup alerts when generation fails.

--- a/background.js
+++ b/background.js
@@ -17,7 +17,7 @@ async function getSelectedText(tabId) {
 async function generateImageFromSelection(tab) {
   const text = await getSelectedText(tab.id);
   if (!text) return;
-  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'openaiStyle', 'stylePrompt']);
+  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'stylePrompt']);
   if (!opts.apiKey) {
     chrome.runtime.openOptionsPage();
     return;
@@ -25,7 +25,6 @@ async function generateImageFromSelection(tab) {
   const prompt = opts.stylePrompt ? `${text}, ${opts.stylePrompt}` : text;
   const size = opts.size || '1024x1024';
   const quality = opts.quality || 'standard';
-  const style = opts.openaiStyle || 'vivid';
   let progressWin;
   try {
     progressWin = await chrome.windows.create({
@@ -46,8 +45,7 @@ async function generateImageFromSelection(tab) {
         n: 1,
         size,
         model: 'gpt-image-1',
-        quality,
-        style
+        quality
       })
     });
     const data = await resp.json();

--- a/options.html
+++ b/options.html
@@ -20,12 +20,6 @@
       <option value="hd">HD</option>
     </select>
   </label><br>
-  <label>OpenAI Style:
-    <select id="openaiStyle">
-      <option value="vivid">Vivid</option>
-      <option value="natural">Natural</option>
-    </select>
-  </label><br>
   <label>Additional Style Text:
     <input id="stylePrompt" type="text" placeholder="e.g. cartoon, photorealistic">
   </label><br>

--- a/options.js
+++ b/options.js
@@ -1,9 +1,8 @@
 document.addEventListener('DOMContentLoaded', async () => {
-  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'openaiStyle', 'stylePrompt']);
+  const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'stylePrompt']);
   if (opts.apiKey) document.getElementById('apiKey').value = opts.apiKey;
   if (opts.size) document.getElementById('size').value = opts.size;
   if (opts.quality) document.getElementById('quality').value = opts.quality;
-  if (opts.openaiStyle) document.getElementById('openaiStyle').value = opts.openaiStyle;
   if (opts.stylePrompt) document.getElementById('stylePrompt').value = opts.stylePrompt;
 });
 
@@ -11,9 +10,8 @@ document.getElementById('save').addEventListener('click', async () => {
   const apiKey = document.getElementById('apiKey').value;
   const size = document.getElementById('size').value;
   const quality = document.getElementById('quality').value;
-  const openaiStyle = document.getElementById('openaiStyle').value;
   const stylePrompt = document.getElementById('stylePrompt').value;
-  await chrome.storage.local.set({apiKey, size, quality, openaiStyle, stylePrompt});
+  await chrome.storage.local.set({apiKey, size, quality, stylePrompt});
   const status = document.getElementById('status');
   status.textContent = 'Saved!';
   setTimeout(() => status.textContent = '', 1000);


### PR DESCRIPTION
## Summary
- revert README to mention GPT-Image-1 and remove style option from features
- drop OpenAI style option from the options page and script
- remove unsupported `style` parameter and use the `gpt-image-1` model

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688685feeb108323b786b082e88f9f9c