### PR TITLE
Fix quality options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ saved automatically to your Downloads folder.
 
 - Highlight text and use the context menu or the extension button to generate an image.
 - OpenAI API key stored via the options page.
-- Choose image size and quality in settings.
+- Choose image size and quality (auto/high/medium/low) in settings.
 - Append custom style text to the prompt.
 - Shows a progress window while the image is being generated.
 - Errors are shown as popup alerts when generation fails.

--- a/background.js
+++ b/background.js
@@ -24,7 +24,7 @@ async function generateImageFromSelection(tab) {
   }
   const prompt = opts.stylePrompt ? `${text}, ${opts.stylePrompt}` : text;
   const size = opts.size || '1024x1024';
-  const quality = opts.quality || 'standard';
+  const quality = opts.quality || 'auto';
   let progressWin;
   try {
     progressWin = await chrome.windows.create({

--- a/options.html
+++ b/options.html
@@ -16,8 +16,10 @@
   </label><br>
   <label>Quality:
     <select id="quality">
-      <option value="standard">Standard</option>
-      <option value="hd">HD</option>
+      <option value="auto">Auto</option>
+      <option value="high">High</option>
+      <option value="medium">Medium</option>
+      <option value="low">Low</option>
     </select>
   </label><br>
   <label>Additional Style Text:

--- a/options.js
+++ b/options.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const opts = await chrome.storage.local.get(['apiKey', 'size', 'quality', 'stylePrompt']);
   if (opts.apiKey) document.getElementById('apiKey').value = opts.apiKey;
   if (opts.size) document.getElementById('size').value = opts.size;
-  if (opts.quality) document.getElementById('quality').value = opts.quality;
+  document.getElementById('quality').value = opts.quality || 'auto';
   if (opts.stylePrompt) document.getElementById('stylePrompt').value = opts.stylePrompt;
 });
 


### PR DESCRIPTION
## Summary
- update README instructions on quality
- change quality dropdown values to auto/high/medium/low
- default options page quality to `auto`
- default background script quality to `auto`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886881438488323b5a83a675eca1704