### PR TITLE
Fix error due to unsupported response_format

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,8 +45,7 @@ async function generateImageFromSelection(tab) {
         n: 1,
         size,
         model: 'gpt-image-1',
-        quality,
-        response_format: 'url'
+        quality
       })
     });
     const data = await resp.json();


### PR DESCRIPTION
## Summary
- remove the `response_format` option from the image generation request

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68868bc286108323870da3cc146bb2e2