### PR TITLE
Fix popup image rendering

### DIFF
--- a/background.js
+++ b/background.js
@@ -73,7 +73,9 @@ async function generateImageFromSelection(tab) {
       throw new Error('Image URL missing in response');
     }
     chrome.downloads.download({url, filename: 'generated.png', saveAs: false});
-    chrome.windows.create({url});
+    const viewer = chrome.runtime.getURL('viewer.html') +
+                  '?url=' + encodeURIComponent(url);
+    chrome.windows.create({url: viewer});
     chrome.windows.remove(progressWin.id);
   } catch (e) {
     console.error(e);

--- a/viewer.html
+++ b/viewer.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Generated Image</title>
+  <style>
+    body { margin:0; display:flex; align-items:center; justify-content:center; background:#000; }
+    img { max-width:100%; max-height:100%; }
+  </style>
+</head>
+<body>
+  <img id="img">
+  <script src="viewer.js"></script>
+</body>
+</html>

--- a/viewer.js
+++ b/viewer.js
@@ -1,0 +1,8 @@
+// Display generated image passed via query parameter
+window.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(location.search);
+  const url = params.get('url');
+  if (url) {
+    document.getElementById('img').src = url;
+  }
+});


### PR DESCRIPTION
## Summary
- add viewer page to render returned images
- open generated images in new viewer page instead of direct URL

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886912bf4888323b18f2480c93b9bd2